### PR TITLE
adding the counter management script

### DIFF
--- a/cm4/configuration/counter.py
+++ b/cm4/configuration/counter.py
@@ -1,4 +1,9 @@
 from __future__ import print_function
+from os.path import isfile, expanduser, join, dirname, realpath, exists
+from os import mkdir
+from shutil import copyfile
+import oyaml as yaml
+
 
 class Counter(object):
     """
@@ -7,36 +12,69 @@ class Counter(object):
     vm id or the job id.
     """
 
-    def __init__(self, name="counter", filename="~/.cloudmesh/counter.yaml"):
+    def __init__(self, counter_file_path="~/.cloudmesh/counter.yaml"):
         """
-        :param name: name of the counter
-        :param user: username associated with the counter
-        :param filename: the counter is always stored in this file.
+        :param counter_file_path: the counter is always stored in this file.
                There can be counters with different names in the file.
         """
+        self.counters = {}
+        self.counter_file_path = expanduser(counter_file_path)
+        config_folder = dirname(self.counter_file_path)
 
-    def incr(cls, name='counter'):
+        if not exists(config_folder):
+            mkdir(config_folder)
+
+        if not isfile(self.counter_file_path):
+            copyfile(join(dirname(realpath(__file__)), "../etc/counter.yaml"), self.counter_file_path)
+
+        with open(self.counter_file_path, "r") as stream:
+            self.counters = yaml.load(stream)
+
+    def incr(self, name='counter'):
         """
         increments the counter by one
         :return:
         """
-        raise NotImplementedError()
+        counter_value = self.counters.get(name)
+        if counter_value is not None:
+            self.set(name,  counter_value + 1)
+        else:
+            raise AttributeError("Counters does not contain a counter with the name: " + name)
 
-    def get(cls, name='counter'):
+    def decr(self, name='counter'):
+        """
+        increments the counter by one
+        :return:
+        """
+        counter_value = self.counters.get(name)
+        if counter_value is not None:
+            # make sure the counter doesn't go below 0
+            counter_value = 0 if counter_value <= 1 else counter_value - 1
+            self.set(name, counter_value)
+        else:
+            raise AttributeError("Counters does not contain a counter with the name: " + name)
+
+    def get(self, name='counter'):
         """
         returns the value of the counter
         :param name: name of the counter
         :return: the value of the counter
         """
-        raise NotImplementedError()
+        return self.counters.get(name)
 
-    def set(cls, name='counter', value=None):
+    def set(self, name='counter', value=None):
         """
         sets a counter associated with a particular user
         :param name: name of the counter
         :param value: the value
         :return:
         """
-        # test if value is an int
-        # than set
-        raise NotImplementedError()
+        # checking if the value is an int
+        if isinstance(value, int):
+            self.counters.__setitem__(name, value)
+            with open(self.counter_file_path, "w") as stream:
+                yaml.safe_dump(self.counters.copy(), stream, default_flow_style=False)
+        elif value is None:
+            raise ValueError("The value for the counter cannot be empty")
+        else:
+            raise ValueError("The value for the counter must be of type int")

--- a/cm4/etc/counter.yaml
+++ b/cm4/etc/counter.yaml
@@ -1,0 +1,3 @@
+counter: 0
+usr1_counter: 0
+usr2_counter: 2


### PR DESCRIPTION
Counters file **can** support multiple counters with different names and they can be managed by providing their name in the functions. 

By default, if no name is provided, the default "counter" is accessed. 