### PR TITLE
adding the initial version of the cm4 rest api with mongo db

### DIFF
--- a/cm4/flask_rest_api/README.md
+++ b/cm4/flask_rest_api/README.md
@@ -1,0 +1,15 @@
+## CM4 REST Api
+
+The cm4 REST Api is built using flask and provides the cloud information retrieval functionality through HTTP calls.
+
+#### Pre-requisites
+Use pip install to install the following packages.
+
+Flask
+Flask-PyMongo
+
+#### Examples
+- Retrieve information about a VM \
+  ```bash 
+  curl localhost:5000/vm/i-0fad7e92ffea8b345
+  ```

--- a/cm4/flask_rest_api/app/__init__.py
+++ b/cm4/flask_rest_api/app/__init__.py
@@ -1,0 +1,12 @@
+from flask import Flask
+from flask_pymongo import PyMongo
+
+from cm4.flask_rest_api.rest_config import Config
+
+app = Flask(__name__)
+app.config.from_object(Config)
+
+mongo = PyMongo(app)
+cloud = mongo.db.cloud
+
+from cm4.flask_rest_api.app import routes

--- a/cm4/flask_rest_api/app/routes.py
+++ b/cm4/flask_rest_api/app/routes.py
@@ -1,0 +1,24 @@
+from cm4.flask_rest_api.app import app
+from cm4.flask_rest_api.app import cloud
+from flask import request, jsonify
+
+
+@app.route('/')
+@app.route('/index')
+def index():
+    return "This is the REST API for cm4"
+
+
+@app.route('/vm/<vm_id>', methods=['GET'])
+def get_vm_info(vm_id):
+    """
+    Returns the VM information for the provided vm_id.
+    :param id: id of the VM
+    :return: a json with the vm information
+    """
+    vm = cloud.find_one({'id' : vm_id})
+    if not vm:
+        return jsonify({'message': "The VM with the id: " + vm_id + " does not exist"}), 401
+
+    del vm['_id']
+    return jsonify({'VM': vm})

--- a/cm4/flask_rest_api/rest_api.py
+++ b/cm4/flask_rest_api/rest_api.py
@@ -1,0 +1,4 @@
+from cm4.flask_rest_api.app import app
+
+if __name__ == "__main__":
+    app.run(debug=True, threaded=True)

--- a/cm4/flask_rest_api/rest_config.py
+++ b/cm4/flask_rest_api/rest_config.py
@@ -1,0 +1,7 @@
+class Config(object):
+    MONGO_DBNAME = "cloudmesh"
+    MONGO_HOST = "127.0.0.1"
+    MONGO_PORT = "27017"
+    MONGO_USERNAME = "admin"
+    MONGO_PASSWORD = "admin"
+    MONGO_URI = "mongodb://" + MONGO_USERNAME + ":" + MONGO_PASSWORD + "@" + MONGO_HOST + ":" + MONGO_PORT + "/" + MONGO_DBNAME


### PR DESCRIPTION
This adds support to the REST API connection with MongoDB. 
Currently supports getting the vm information via /vm/id. 

More information is available in the README.md