### PR TITLE
Add timeout mechanism for float_ip association, and fix duplicate ssh-key file importation error

### DIFF
--- a/cm4/openstack/test/demo.py
+++ b/cm4/openstack/test/demo.py
@@ -3,7 +3,7 @@ from time import sleep
 import datetime
 
 # testcode
-# need extra waiting time so server can finish update the node states
+# need extra waiting time so server can finish update the node status
 # pending - running - stopped
 
 def main():
@@ -58,8 +58,6 @@ def main():
     d.destroy(node_id)
     sleep(10)
 
-
-    d.ls()
 
 
 if __name__ == "__main__":

--- a/cm4/vm/Vm.py
+++ b/cm4/vm/Vm.py
@@ -37,10 +37,13 @@ class Vm:
     def __init__(self, cloud):
         config = Config()
         self.provider = Vmprovider().get_provider(cloud)
+
         self.mongo = MongoDB(host=config.get('data.mongo.MONGO_HOST'),
                              username=config.get('data.mongo.MONGO_USERNAME'),
                              password=config.get('data.mongo.MONGO_PASSWORD'),
                              port=config.get('data.mongo.MONGO_PORT'))
+        #print(config.get('data.mongo.MONGO_HOST'))
+
 
     def start(self, name):
         """
@@ -48,7 +51,6 @@ class Vm:
         :param name:
         :return: VM document
         """
-
         info = self.info(name)
         if info.state != 'running':
             self.provider.ex_start_node(info)
@@ -109,8 +111,6 @@ class Vm:
         node = self.provider.create_node(name)
         self.mongo.insert_cloud_document(vars(node))
         return node
-        # node = self.provider.create_node(name=name, **self.provider.get_new_node_setting())
-        # return node
 
     def list(self):
         """
@@ -140,7 +140,10 @@ class Vm:
         for i in nodes:
             if i.name == name:
                 document = vars(i)
-                self.mongo.update_document('cloud', 'name', name, document)
+                if self.mongo.find_document('cloud', 'name', name):
+                    self.mongo.update_document('cloud', 'name', name, document)
+                else:
+                    self.mongo.insert_cloud_document(document)
                 return i
 
     def new_name(self, experiment, group, user):

--- a/cm4/vm/VmRefactor.py
+++ b/cm4/vm/VmRefactor.py
@@ -12,8 +12,9 @@ from cm4.configuration.config import Config
 import cm4.vm.VmUtil as util
 
 
-###
-### provide generic methods to manipulate nodes from various providers by name
+"""
+provide generic methods to manipulate nodes from various providers by name
+"""
 
 class VmRefactor(object):
     def __init__(self, vm):
@@ -99,7 +100,6 @@ class VmRefactor(object):
                 self.vm.mongo.update_document('cloud', 'name', name, document)
                 return i
         raise ValueError('Node with name: \"'+name+'\" was not found!')
-
 
 
     def list_sizes(self):

--- a/cm4/vm/tests/demo_flavors.py
+++ b/cm4/vm/tests/demo_flavors.py
@@ -15,10 +15,9 @@ def main():
     # test for openstack
     # input("Press Enter to connect to MongoDB....")
     openstack = Vm('chameleon')
-    openstack.start('cm_test_small')
+    openstack.create('ruili-01')
 
 
-    
     print(openstack.mongo.username)
     print(openstack.mongo.password)
     print(openstack.mongo.client)

--- a/cm4/vm/tests/demo_flavors.py
+++ b/cm4/vm/tests/demo_flavors.py
@@ -15,20 +15,23 @@ def main():
     # test for openstack
     # input("Press Enter to connect to MongoDB....")
     openstack = Vm('chameleon')
+    openstack.start('cm_test_small')
 
+
+    
     print(openstack.mongo.username)
     print(openstack.mongo.password)
     print(openstack.mongo.client)
     print(openstack.mongo.db['config'])
-    print(openstack.mongo.db.collection_names(include_system_collections=False))
+    #print(openstack.mongo.db.collection_names(include_system_collections=False))
 
-    return
+
     list = openstack.list()
     pprint(list)
     pprint(list[0])
 
     print(openstack.info('cm_test_small'))
-    openstack.start('cm_test_small')
+
 
     name = openstack.list()[0].name
     refactor = VmRefactor(openstack)


### PR DESCRIPTION
1. Usually, node creation needs a period of time to spawn. If we try to access the node, an exception will be raised. Timeout here is to prevent such unexpected and indeterministic running
2. import key file need not be executed everytime we run the cm. In fact for each machine, we only need to import once. Key-pair already exists exception may be raised in some running
3. quick fix to cmmongodb