### PR TITLE
Fixes WGET and SystemPath

### DIFF
--- a/cloudmesh/mongo/MongoDBController.py
+++ b/cloudmesh/mongo/MongoDBController.py
@@ -82,13 +82,11 @@ class MongoInstaller(object):
         mkdir -p {MONGO_PATH}
         mkdir -p {MONGO_HOME}
         mkdir -p {MONGO_LOG}
-        wget -P /tmp/mongodb.tgz {MONGO_CODE}
+        wget -O /tmp/mongodb.tgz {MONGO_CODE}
         tar -zxvf /tmp/mongodb.tgz -C {LOCAL}/mongo --strip 1
+        echo \"export PATH={MONGO_HOME}/bin:$PATH\" >> ~/.bashrc
             """.format(**self.data)
         installer = Script.run(script)
-        SystemPath.add("{MONGO_HOME}/bin".format(**self.data))
-
-        # THIS IS BROKEN AS ITS A SUPBROCESS? '. ~/.bashrc'
 
     # noinspection PyUnusedLocal
     def darwin(self, brew=False):


### PR DESCRIPTION
Changed the WGET command to use -O instead of -P to write the mongodb download to a file rather than a new folder (e.g. write as mongodb.tgz rather than mongodb.tgz/mongodb-download-file-name.tgz).

The SystemPath was also broken as 'source ~./bashrc' fails since it's being installed as a subprocess. I changed the install script to simply update the PATH itself rather than using SystemPath (I didn't want to change SystemPath and break a whole bunch of other things).