### PR TITLE
Remove manager import

### DIFF
--- a/cloudmesh/terminal/command/terminal.py
+++ b/cloudmesh/terminal/command/terminal.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from cloudmesh.shell.command import command, map_parameters
 from cloudmesh.shell.command import PluginCommand
-from cloudmesh.login.api.manager import Manager
+#from cloudmesh.login.api.manager import Manager
 from cloudmesh.common.console import Console
 from cloudmesh.common.util import path_expand
 from pprint import pprint


### PR DESCRIPTION
Commented out 'import of from cloudmesh.login.api.manager import Manager'. The file does not exist and causes CMS to fail on fresh installs, nor is it used in terminal.py (m = Manager() is commented out and there are no other references to 'm').