### PR TITLE
Update requirements to support Docker module.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ colorama
 config
 coverage
 docopt
+docker
 idna
 oyaml
 pymongo


### PR DESCRIPTION
Tried to update CMS - it fails to launch on a clean install since it does not download the Docker package. The offending line is in: /cm/blob/master/cloudmesh/compute/docker/Provider.py on line 8. Updating requirements here.